### PR TITLE
Release v1.1.1 and 5.0.0 compatibility changes

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -43,6 +43,11 @@
     Random Avatar Plugin Changelog
 </h1>
 
+<p><b>1.1.1</b> -- November 20, 2024</p>
+<ul>
+    <li>Marked as last version to be compatible with Openfire versions prior to 5.0.0.</li>
+</ul>
+
 <p><b>1.1.0</b> -- May 23, 2023</p>
 <ul>
     <li>Remove unused exclusion to authentication filter</li>

--- a/changelog.html
+++ b/changelog.html
@@ -43,6 +43,12 @@
     Random Avatar Plugin Changelog
 </h1>
 
+<p><b>1.2.0</b> -- (to be determined)</p>
+<ul>
+    <li>Requires Openfire 5.0.0 or later</li>
+    <li><a href="https://github.com/igniterealtime/openfire-randomavatar-plugin/issues/5">#5:</a> Openfire 5.0.0 compatibility</li>
+</ul>
+
 <p><b>1.1.1</b> -- November 20, 2024</p>
 <ul>
     <li>Marked as last version to be compatible with Openfire versions prior to 5.0.0.</li>

--- a/plugin.xml
+++ b/plugin.xml
@@ -5,7 +5,8 @@
     <description>${project.description}</description>
     <author>Guus der Kinderen</author>
     <version>${project.version}</version>
-    <date>2023-05-23</date>
+    <date>2024-11-20</date>
     <minServerVersion>4.1.5</minServerVersion>
+    <priorToServerVersion>5.0.0</priorToServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,5 @@
     <author>Guus der Kinderen</author>
     <version>${project.version}</version>
     <date>2024-11-20</date>
-    <minServerVersion>4.1.5</minServerVersion>
-    <priorToServerVersion>5.0.0</priorToServerVersion>
-    <minJavaVersion>1.8</minJavaVersion>
+    <minServerVersion>5.0.0</minServerVersion>
 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>randomavatar</artifactId>
-    <version>1.1.1</version>
+    <version>1.2.0-SNAPSHOT</version>
 
     <name>Random Avatar Generator Plugin</name>
     <description>Generates semi-random avatar images.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>randomavatar</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.1</version>
 
     <name>Random Avatar Generator Plugin</name>
     <description>Generates semi-random avatar images.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.igniterealtime.openfire.plugins</groupId>
@@ -34,8 +34,8 @@
             </plugin>
             <!-- Compiles the Openfire Admin Console JSP pages.
             <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-jspc-maven-plugin</artifactId>
+                <groupId>org.eclipse.jetty.ee8</groupId>
+                <artifactId>jetty-ee8-jspc-maven-plugin</artifactId>
             </plugin> -->
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>randomavatar</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
 
     <name>Random Avatar Generator Plugin</name>
     <description>Generates semi-random avatar images.</description>

--- a/src/java/org/igniterealtime/openfire/plugins/randomavatar/RandomAvatarPlugin.java
+++ b/src/java/org/igniterealtime/openfire/plugins/randomavatar/RandomAvatarPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2019-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,7 @@
  */
 package org.igniterealtime.openfire.plugins.randomavatar;
 
-import org.apache.tomcat.InstanceManager;
-import org.apache.tomcat.SimpleInstanceManager;
-import org.eclipse.jetty.apache.jsp.JettyJasperInitializer;
-import org.eclipse.jetty.plus.annotation.ContainerInitializer;
-import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.jetty.ee8.webapp.WebAppContext;
 import org.jivesoftware.openfire.container.Plugin;
 import org.jivesoftware.openfire.container.PluginManager;
 import org.jivesoftware.openfire.http.HttpBindManager;
@@ -27,8 +23,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * An Openfire plugin that makes available an avatar-exposing webservice.
@@ -56,10 +50,6 @@ public class RandomAvatarPlugin implements Plugin
         context.setClassLoader( this.getClass().getClassLoader() );
 
         Log.debug( "Ensure the JSP engine is initialized correctly (in order to be able to cope with Tomcat/Jasper precompiled JSPs)." );
-        final List<ContainerInitializer> initializers = new ArrayList<>();
-        initializers.add( new ContainerInitializer( new JettyJasperInitializer(), null ) );
-        context.setAttribute( "org.eclipse.jetty.containerInitializers", initializers );
-        context.setAttribute( InstanceManager.class.getName(), new SimpleInstanceManager() );
         context.setAttribute( "org.igniterealtime.openfire.plugins.randomavatar.plugindirectory", pluginDirectory.toPath() );
         Log.debug( "Registering context with the embedded webserver." );
         HttpBindManager.getInstance().addJettyHandler( context );


### PR DESCRIPTION
This, in order:

1. drafts a release, which is also marked as being compatible with Openfire < 5.0.0
2. makes changes to be compatible with Openfire 5.0.0

The idea behind this is that we'll have one last plugin that's compatible with older versions of Openfire, while preparing for a new plugin release that is compatible with Openfire 5.0.0 and later.
